### PR TITLE
Allow duplicate callsites if result matches schema

### DIFF
--- a/lib/schema_test/minitest.rb
+++ b/lib/schema_test/minitest.rb
@@ -35,8 +35,13 @@ module SchemaTest
     def queue_write_expanded_assert_api_call(call_site, method, name, version, location, expected_schema)
       file, line = call_site.split(':')
       line_index = line.to_i.pred
+      schema_call = [line_index, method, name, version, location, expected_schema]
 
       @@__api_schema_calls_for_expansion[file] ||= []
+      if (existing_call = @@__api_schema_calls_for_expansion[file].find { |call| line_index == call[0] })
+        return if existing_call == schema_call
+        raise "Expected schema does not match for duplicate API schema assertion at #{call_site}"
+      end
       @@__api_schema_calls_for_expansion[file] << [line_index, method, name, version, location, expected_schema]
     end
 


### PR DESCRIPTION
Previously if `assert_valid_json_for_schema` was called in a loop (e.g. tests/contexts defined dynamically), `schema-test` would try to rewrite the same callsite multiple times, which works the first time but fails afterwards because the file was already updated.

Now we check if we visited this site before and quietly continue if the expected result is the same. If the result is different between the assertions we raise to inform the user his expectation performs differently within each loop.