### PR TITLE
Add option to disable rubocop within expanded code

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ require 'schema_test/minitest'
 SchemaTest.configure do |config|
   config.domain = 'mydomain.com'
   config.definition_paths << Rails.root.join('test', 'schema_definitions')
+  config.disable_rubocop = true # optional, set to true if using rubocop to disable it in the generated code
 end
 SchemaTest.load!
 ```

--- a/lib/schema_test/configuration.rb
+++ b/lib/schema_test/configuration.rb
@@ -9,9 +9,14 @@ module SchemaTest
     # files in as many subdirectories are you like.
     attr_accessor :definition_paths
 
+    # Set to true in order to disable running rubocop on the expanded schemas,
+    # as the Ruby PP output does not conform to rubocop's standards.
+    attr_accessor :disable_rubocop
+
     def initialize
       @domain = 'example.com'
       @definition_paths = []
+      @disable_rubocop = false
     end
   end
 end

--- a/lib/schema_test/minitest.rb
+++ b/lib/schema_test/minitest.rb
@@ -54,7 +54,8 @@ module SchemaTest
     def expand_assert_api_calls
      @@__api_schema_calls_for_expansion.each do |file, line_indexes_with_schemas|
        original_contents = File.read(file)
-       rewriter = SchemaTest::Rewriter.new(original_contents, line_indexes_with_schemas)
+       rewriter_options = { disable_rubocop: SchemaTest.configuration.disable_rubocop }
+       rewriter = SchemaTest::Rewriter.new(original_contents, line_indexes_with_schemas, options: rewriter_options)
        new_contents = rewriter.output
        raise "Error rewriting file" if new_contents.blank?
        File.open(file, 'w') { |f| f.puts new_contents }

--- a/lib/schema_test/rewriter.rb
+++ b/lib/schema_test/rewriter.rb
@@ -4,23 +4,35 @@ module SchemaTest
   OPENING_COMMENT = '# EXPANDED'.freeze
   CLOSING_COMMENT = '# END EXPANDED'.freeze
 
+  DISABLE_RUBOCOP_COMMENT = '# rubocop:disable all'.freeze
+  ENABLE_RUBOCOP_COMMENT = '# rubocop:enable all'.freeze
+
   class Rewriter
-    def initialize(contents, line_indexes_with_schemas)
+    def initialize(contents, line_indexes_with_schemas, options: {})
       @lines = contents.split("\n")
       @line_indexes_with_schemas = line_indexes_with_schemas
+
+      @disable_rubocop = options.fetch(:disable_rubocop, false)
     end
 
     def output
       current_offset = 0
       line_indexes_with_schemas.sort_by { |(line,_)| line }.each do |index, method, name, version, location, expected_schema|
         start_index = index + current_offset
+        if lines[start_index - 1].match?(/#{DISABLE_RUBOCOP_COMMENT}/)
+          lines.delete_at(start_index - 1)
+          start_index -= 1
+        end
+
         if lines[start_index] =~ /#{OPENING_COMMENT}/
           end_index = start_index + lines[start_index..-1].find_index { |line| line =~ /#{CLOSING_COMMENT}\s*\z/ }
+          lines.delete_at(end_index + 1) if lines[end_index + 1].match?(/#{ENABLE_RUBOCOP_COMMENT}/)
           json_variable_name = lines[start_index + 1].strip.gsub(/,\z/, '')
         else
           end_index = start_index
           json_variable_name = lines[start_index].match(/\(([^,]+)/)[1]
         end
+
         original_method_definition_length = end_index - start_index
         start_indent = lines[start_index].match(/\A(\s*)/)[0].length
         (end_index - start_index + 1).times { |i| lines.delete_at(start_index) }
@@ -32,10 +44,12 @@ module SchemaTest
         expanded_schema_lines.unshift(json_variable_name + ',')
 
         method_string = [
+          disable_rubocop ? (' ' * start_indent) + DISABLE_RUBOCOP_COMMENT : nil,
           (' ' * start_indent) + method.to_s + "( #{OPENING_COMMENT} from #{location}",
           *expanded_schema_lines.map { |line| (' ' * (start_indent + 2)) + line },
-          (' ' * start_indent) + ") #{CLOSING_COMMENT}"
-        ]
+          (' ' * start_indent) + ") #{CLOSING_COMMENT}",
+          disable_rubocop ? (' ' * start_indent) + ENABLE_RUBOCOP_COMMENT: nil,
+        ].compact
 
         method_string.reverse.each { |line| lines.insert(start_index, line) }
 
@@ -48,5 +62,6 @@ module SchemaTest
     private
 
     attr_reader :lines, :line_indexes_with_schemas
+    attr_reader :disable_rubocop
   end
 end


### PR DESCRIPTION
For projects using rubocop it's useful to have an option to disable rubocop within the code blocks generated by schema-test.