### PR TITLE
Handle offset in rubocop-disabled code

### DIFF
--- a/lib/schema_test/rewriter.rb
+++ b/lib/schema_test/rewriter.rb
@@ -22,11 +22,12 @@ module SchemaTest
         if lines[start_index - 1].match?(/#{DISABLE_RUBOCOP_COMMENT}/)
           lines.delete_at(start_index - 1)
           start_index -= 1
+          current_offset -= 2
         end
 
         if lines[start_index] =~ /#{OPENING_COMMENT}/
           end_index = start_index + lines[start_index..-1].find_index { |line| line =~ /#{CLOSING_COMMENT}\s*\z/ }
-          lines.delete_at(end_index + 1) if lines[end_index + 1].match?(/#{ENABLE_RUBOCOP_COMMENT}/)
+          lines.delete_at(end_index + 1) if lines[end_index + 1]&.match?(/#{ENABLE_RUBOCOP_COMMENT}/)
           json_variable_name = lines[start_index + 1].strip.gsub(/,\z/, '')
         else
           end_index = start_index

--- a/spec/schema_test/rewriter_spec.rb
+++ b/spec/schema_test/rewriter_spec.rb
@@ -294,10 +294,19 @@ assert_schema( # EXPANDED from path/schema.rb:1
   :arg1, {:version=>:arg2, :schema=>:expanded_contents}
 ) # END EXPANDED
 # rubocop:enable all
-line 3
+line 9
+# rubocop:disable all
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
      FILE
 
-    rewriter = described_class.new(input, [[3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]], options: { disable_rubocop: true })
+    rewriter = described_class.new(input, [
+                                     [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+                                     [10, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:10', :expanded_contents2]
+                                   ], options: { disable_rubocop: true })
     expect(rewriter.output).to eq(<<~FILE)
 line 1
 line 2
@@ -307,7 +316,13 @@ assert_schema( # EXPANDED from path/schema.rb:1
   :arg1, {:version=>:arg2, :schema=>:expanded_contents}
 ) # END EXPANDED
 # rubocop:enable all
-line 3
+line 9
+# rubocop:disable all
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+# rubocop:enable all
      FILE
   end
 
@@ -335,4 +350,157 @@ assert_schema( # EXPANDED from path/schema.rb:1
 line 3
      FILE
   end
+
+  it 'handles a mix of rubocop blocks and non-rubocop blocks' do
+    input = <<~FILE
+line 1
+line 2
+# rubocop:disable all
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 9
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+
+    rewriter = described_class.new(input, [
+                                     [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+                                     [9, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:10', :expanded_contents2]
+                                   ], options: { disable_rubocop: true })
+    expect(rewriter.output).to eq(<<~FILE)
+line 1
+line 2
+# rubocop:disable all
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 9
+# rubocop:disable all
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+# rubocop:enable all
+    FILE
+  end
+
+  it 'handles mismatched rubocop blocks' do
+    input = <<~FILE
+line 1
+line 2
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 8
+# rubocop:disable all
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+
+    rewriter = described_class.new(input, [
+                                     [2, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+                                     [8, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:10', :expanded_contents2]
+                                   ], options: { disable_rubocop: true })
+    expect(rewriter.output).to eq(<<~FILE)
+line 1
+line 2
+# rubocop:disable all
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 8
+# rubocop:disable all
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+# rubocop:enable all
+    FILE
+  end
+
+  it 'can disable a mix of rubocop and non-rubocop blocks' do
+    input = <<~FILE
+line 1
+line 2
+# rubocop:disable all
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 9
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+
+    rewriter = described_class.new(input, [
+                                     [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+                                     [9, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:10', :expanded_contents2]
+                                   ])
+    expect(rewriter.output).to eq(<<~FILE)
+line 1
+line 2
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 9
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+  end
+
+  it 'can disable mismatched rubocop blocks' do
+    input = <<~FILE
+line 1
+line 2
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+# rubocop:enable all
+line 8
+# rubocop:disable all
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+
+    rewriter = described_class.new(input, [
+                                     [2, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+                                     [8, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:10', :expanded_contents2]
+                                   ])
+    expect(rewriter.output).to eq(<<~FILE)
+line 1
+line 2
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 8
+assert_schema( # EXPANDED from path/other_schema.rb:10
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+    FILE
+  end
+
 end


### PR DESCRIPTION
The rewriter works by trying to find and delete any rubocop lines adjacent to the schema assertion, then writes them back at the end if the `disable_rubocop` option is true.

Assuming we delete the rubocop magic comments, the file we operate on becomes 2 lines shorter, so we need to subtract this from the offset.

I've added some tests to assert this case, which requires at least 2 schema assertions in the same file to be validated.