### PR TITLE
Update GH Actions tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,4 +52,4 @@ DEPENDENCIES
   schema-test!
 
 BUNDLED WITH
-   2.1.4
+   2.5.9


### PR DESCRIPTION
- Remove EOL Ruby versions and add supported ones
- Bump to latest actions/checkout
- Use ruby/setup-ruby@v1 instead of pinning to a SHA
- Update bundler to latest to avoid some deprecation warnings with newer rubies