### PR TITLE
Compile schemas to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ In compiled mode the test files no longer contain the expanded schema, so a sche
 ``` ruby
 test 'JSON returned matches schema' do
   json = JSON.parse(response.body)
-  assert_valid_json_for_schema(json, :user, version: 1, fingerprint: "9f2c…")
+  assert_valid_json_for_schema(json, :user, version: 1, fingerprint: '9f2c…')
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,17 +207,23 @@ end
 SchemaTest.compile!
 ```
 
-This will create a `compiled` directory inside your schema definitions directory containing one JSON file per definition:
+This will create a `compiled` directory inside your schema definitions directory containing one JSON file per definition. The compiled files mirror the layout of your original definition files, so a definition declared in `api/v3/film.rb` is compiled to `compiled/api/v3/film.json`:
 
 ```
-test/schema_definitions/compiled/
-├── user.v1.json
-├── user.v2.json
-├── comment.v1.json
-└── comments.v1.json
+test/schema_definitions/
+├── api/
+│   └── v3/
+│       ├── film.rb
+│       └── user.rb
+└── compiled/
+    └── api/
+        └── v3/
+            ├── film.json
+            ├── user.v1.json
+            └── user.v2.json
 ```
 
-Versioned definitions are named `<name>.v<version>.json`; unversioned ones are simply `<name>.json`.
+Versioned definitions are named `<name>.v<version>.json`; unversioned ones are simply `<name>.json`. Definitions without a known source location are written to the root of the `compiled` directory.
 
 Your test assertions stay the same — `assert_valid_json_for_schema` will load the pre-compiled JSON schema file and validate against it:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,19 @@ end
 
 You can commit the compiled JSON files to your repository so that the schemas used in tests are visible in diffs, or add `compiled/` to your `.gitignore` and regenerate them as part of your test setup.
 
+#### Schema fingerprints
+
+In compiled mode the test files no longer contain the expanded schema, so a schema change wouldn't otherwise show up as a diff in the tests themselves. To keep that feedback, each assertion records a `fingerprint:` argument — a SHA-256 of the compiled schema:
+
+``` ruby
+test 'JSON returned matches schema' do
+  json = JSON.parse(response.body)
+  assert_valid_json_for_schema(json, :user, version: 1, fingerprint: "9f2c…")
+end
+```
+
+You don't write the fingerprint by hand. When you run the tests locally, the assertion compares the fingerprint argument against the compiled schema and, if it is missing or stale, rewrites it in place. The resulting diff points at exactly which API endpoints changed. In CI (when `ENV['CI']` is set) a mismatched or missing fingerprint fails the test instead of rewriting it, so out-of-date assertions can't be merged.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,45 @@ end
 ```
 Keeping the full schema directly in the tests means that it is **impossible** for us to accidentally impact any API endpoints with a distant schema change without also producing some change in the test files for those endpoints. That is the main benefit that this library tries to acheive.
 
+### Compiled mode
+
+As an alternative to inlining expanded schemas into your test files, you can use **compiled mode**. In this mode, all schema definitions are compiled to standalone JSON Schema files on disk, and test assertions validate against those files directly. No test file rewriting happens.
+
+To enable it, update your `test_helper.rb`:
+
+``` ruby
+require 'schema_test/minitest'
+SchemaTest.configure do |config|
+  config.domain = 'mydomain.com'
+  config.definition_paths << Rails.root.join('test', 'schema_definitions')
+  config.compiled = true
+end
+SchemaTest.compile!
+```
+
+This will create a `compiled` directory inside your schema definitions directory containing one JSON file per definition:
+
+```
+test/schema_definitions/compiled/
+├── user.v1.json
+├── user.v2.json
+├── comment.v1.json
+└── comments.v1.json
+```
+
+Versioned definitions are named `<name>.v<version>.json`; unversioned ones are simply `<name>.json`.
+
+Your test assertions stay the same — `assert_valid_json_for_schema` will load the pre-compiled JSON schema file and validate against it:
+
+``` ruby
+test 'JSON returned matches schema' do
+  json = JSON.parse(response.body)
+  assert_valid_json_for_schema(json, :user, version: 1)
+end
+```
+
+You can commit the compiled JSON files to your repository so that the schemas used in tests are visible in diffs, or add `compiled/` to your `.gitignore` and regenerate them as part of your test setup.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/schema_test.rb
+++ b/lib/schema_test.rb
@@ -14,6 +14,13 @@ module SchemaTest
 
   SCHEMA_VERSION = "http://json-schema.org/draft-07/schema#"
 
+  # The number of leading hex characters of the schema digest kept as a
+  # fingerprint. The fingerprint only needs to change when the schema
+  # changes (it is compared against a single expected value, never
+  # searched for collisions), so a short prefix keeps the assertion lines
+  # readable while remaining collision-free in practice.
+  FINGERPRINT_LENGTH = 12
+
   class << self
     def reset!
       @configuration = nil
@@ -88,7 +95,7 @@ module SchemaTest
     # derived from the schema's semantic content, so it changes whenever
     # the schema changes but is unaffected by pretty-print formatting.
     def schema_fingerprint(schema)
-      Digest::SHA256.hexdigest(JSON.generate(schema))
+      Digest::SHA256.hexdigest(JSON.generate(schema))[0, FINGERPRINT_LENGTH]
     end
 
     # Collapse expanded schema assertions in test files back to

--- a/lib/schema_test.rb
+++ b/lib/schema_test.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'schema_test/version'
 require 'schema_test/rewriter'
 require 'schema_test/definition'
@@ -44,6 +45,45 @@ module SchemaTest
     # objects)
     def collection(name, of:, **attributes)
       SchemaTest::Collection.new(name, of, location: definition_location(caller[1]), **attributes)
+    end
+
+    # Compile all definitions to JSON Schema files in a `compiled`
+    # directory within each definition path.
+    def compile!
+      load_definitions
+      configuration.definition_paths.each do |definition_path|
+        compiled_path = Pathname.new(definition_path).join('compiled')
+        compiled_path.mkpath
+        SchemaTest::Definition.all.each do |definition|
+          begin
+            schema = definition.as_json_schema
+            filename = if definition.version
+              "#{definition.name}.v#{definition.version}.json"
+            else
+              "#{definition.name}.json"
+            end
+            File.write(compiled_path.join(filename), JSON.pretty_generate(schema) + "\n")
+          rescue => e
+            warn "SchemaTest: failed to compile #{definition.name} (version: #{definition.version}): #{e.message}"
+          end
+        end
+      end
+    end
+
+    # Load a pre-compiled JSON schema from the compiled directory.
+    def load_compiled_schema(name, version: nil)
+      filename = if version
+        "#{name}.v#{version}.json"
+      else
+        "#{name}.json"
+      end
+      configuration.definition_paths.each do |definition_path|
+        path = Pathname.new(definition_path).join('compiled', filename)
+        if path.exist?
+          return JSON.parse(path.read)
+        end
+      end
+      raise SchemaTest::Error, "Could not find compiled schema for #{name.inspect} (version: #{version.inspect})"
     end
 
     # Validate some JSON data against a schema or schema definition

--- a/lib/schema_test.rb
+++ b/lib/schema_test.rb
@@ -49,40 +49,35 @@ module SchemaTest
     end
 
     # Compile all definitions to JSON Schema files in a `compiled`
-    # directory within each definition path.
+    # directory within each definition path. The compiled files mirror
+    # the layout of the original definition files, so a definition
+    # declared in `api/v3/film.rb` is written to
+    # `compiled/api/v3/film.json`.
     def compile!
       load_definitions
-      configuration.definition_paths.each do |definition_path|
-        compiled_path = Pathname.new(definition_path).join('compiled')
-        compiled_path.mkpath
-        SchemaTest::Definition.all.each do |definition|
-          begin
-            schema = definition.as_json_schema
-            filename = if definition.version
-              "#{definition.name}.v#{definition.version}.json"
-            else
-              "#{definition.name}.json"
-            end
-            File.write(compiled_path.join(filename), JSON.pretty_generate(schema) + "\n")
-          rescue => e
-            warn "SchemaTest: failed to compile #{definition.name} (version: #{definition.version}): #{e.message}"
-          end
+      SchemaTest::Definition.all.each do |definition|
+        begin
+          definition_path = owning_definition_path(definition)
+          next unless definition_path
+          path = Pathname.new(definition_path).join('compiled', compiled_relative_path(definition))
+          path.dirname.mkpath
+          File.write(path, JSON.pretty_generate(definition.as_json_schema) + "\n")
+        rescue => e
+          warn "SchemaTest: failed to compile #{definition.name} (version: #{definition.version}): #{e.message}"
         end
       end
     end
 
     # Load a pre-compiled JSON schema from the compiled directory.
+    # Because compiled files mirror the original definition layout, the
+    # file may live in a nested subdirectory, so the compiled tree is
+    # searched recursively for the expected filename.
     def load_compiled_schema(name, version: nil)
-      filename = if version
-        "#{name}.v#{version}.json"
-      else
-        "#{name}.json"
-      end
+      filename = compiled_filename(name, version)
       configuration.definition_paths.each do |definition_path|
-        path = Pathname.new(definition_path).join('compiled', filename)
-        if path.exist?
-          return JSON.parse(path.read)
-        end
+        compiled_root = Pathname.new(definition_path).join('compiled')
+        match = Pathname.glob(compiled_root.join('**', filename)).first
+        return JSON.parse(match.read) if match
       end
       raise SchemaTest::Error, "Could not find compiled schema for #{name.inspect} (version: #{version.inspect})"
     end
@@ -118,10 +113,58 @@ module SchemaTest
 
     private
 
+    # The filename a definition compiles to, e.g. `film.json` or
+    # `film.v2.json` for versioned definitions.
+    def compiled_filename(name, version)
+      if version
+        "#{name}.v#{version}.json"
+      else
+        "#{name}.json"
+      end
+    end
+
+    # The relative source file a definition was declared in (without the
+    # trailing line number), or nil if it has no known location.
+    def definition_source_file(definition)
+      return nil unless definition.location
+      source = definition.location.rpartition(':').first
+      source = definition.location if source.empty?
+      source.empty? ? nil : source
+    end
+
+    # The definition path a definition's source file lives under, so
+    # that each schema is compiled exactly once into the `compiled`
+    # directory of its owning path rather than duplicated into every
+    # definition path. Definitions whose source cannot be located (for
+    # example, those constructed directly without a location) fall back
+    # to the first configured definition path.
+    def owning_definition_path(definition)
+      source = definition_source_file(definition)
+      if source
+        owning = configuration.definition_paths.find do |definition_path|
+          Pathname.new(definition_path).join(source).exist?
+        end
+        return owning if owning
+      end
+      configuration.definition_paths.first
+    end
+
+    # The path a definition compiles to, relative to the `compiled`
+    # directory. The directory mirrors the location of the source
+    # definition file (e.g. `api/v3/film.rb` -> `api/v3/film.json`).
+    # Definitions without a known location are written to the root of
+    # the compiled directory.
+    def compiled_relative_path(definition)
+      filename = compiled_filename(definition.name, definition.version)
+      source = definition_source_file(definition)
+      return Pathname.new(filename) unless source
+      Pathname.new(source).dirname.join(filename)
+    end
+
     def definition_location(caller_line)
       path, line = caller_line.split(':').take(2)
       configuration.definition_paths.each do |definition_path|
-        if path.starts_with?(definition_path.to_s)
+        if path.start_with?(definition_path.to_s)
           path = Pathname.new(path).relative_path_from(definition_path)
           break
         end
@@ -131,8 +174,8 @@ module SchemaTest
 
     def load_definitions
       configuration.definition_paths.map! { |p| Pathname.new(p) }
-      globbed_paths = configuration.definition_paths.map { |path| path.join('**', '*.rb') }
-      Dir[globbed_paths.join(',')].each do |schema_file|
+      globbed_paths = configuration.definition_paths.map { |path| path.join('**', '*.rb').to_s }
+      Dir[*globbed_paths].each do |schema_file|
         require schema_file
       end
     end

--- a/lib/schema_test.rb
+++ b/lib/schema_test.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'schema_test/version'
 require 'schema_test/rewriter'
+require 'schema_test/collapser'
 require 'schema_test/definition'
 require 'schema_test/collection'
 require 'schema_test/validator'
@@ -84,6 +85,25 @@ module SchemaTest
         end
       end
       raise SchemaTest::Error, "Could not find compiled schema for #{name.inspect} (version: #{version.inspect})"
+    end
+
+    # Collapse expanded schema assertions in test files back to
+    # simple one-line calls. Pass file paths or directory paths.
+    # Directories are globbed for **/*.rb files.
+    def collapse!(*paths)
+      files = paths.flat_map do |path|
+        if File.directory?(path)
+          Dir[File.join(path, '**', '*.rb')]
+        else
+          [path]
+        end
+      end
+      files.each do |file|
+        contents = File.read(file)
+        next unless contents.include?(OPENING_COMMENT)
+        collapser = SchemaTest::Collapser.new(contents)
+        File.write(file, collapser.output)
+      end
     end
 
     # Validate some JSON data against a schema or schema definition

--- a/lib/schema_test.rb
+++ b/lib/schema_test.rb
@@ -1,6 +1,8 @@
 require 'json'
+require 'digest'
 require 'schema_test/version'
 require 'schema_test/rewriter'
+require 'schema_test/fingerprint_rewriter'
 require 'schema_test/collapser'
 require 'schema_test/definition'
 require 'schema_test/collection'
@@ -80,6 +82,13 @@ module SchemaTest
         return JSON.parse(match.read) if match
       end
       raise SchemaTest::Error, "Could not find compiled schema for #{name.inspect} (version: #{version.inspect})"
+    end
+
+    # A stable fingerprint of a compiled schema. The fingerprint is
+    # derived from the schema's semantic content, so it changes whenever
+    # the schema changes but is unaffected by pretty-print formatting.
+    def schema_fingerprint(schema)
+      Digest::SHA256.hexdigest(JSON.generate(schema))
     end
 
     # Collapse expanded schema assertions in test files back to

--- a/lib/schema_test/collapser.rb
+++ b/lib/schema_test/collapser.rb
@@ -1,0 +1,58 @@
+module SchemaTest
+  class Collapser
+    def initialize(contents)
+      @lines = contents.split("\n")
+    end
+
+    def output
+      result = []
+      i = 0
+      while i < @lines.length
+        line = @lines[i]
+
+        # Skip rubocop:disable line immediately before an EXPANDED block
+        if line.match?(/#{DISABLE_RUBOCOP_COMMENT}/) &&
+            i + 1 < @lines.length && @lines[i + 1].match?(/#{OPENING_COMMENT}/)
+          i += 1
+          next
+        end
+
+        if line =~ /\A(\s*)(\w+)\(\s*#{OPENING_COMMENT}/
+          indent = $1
+          method_name = $2
+
+          # Next line is the json variable
+          json_var = @lines[i + 1].strip.sub(/,\z/, '')
+
+          # Gather remaining content lines until closing marker
+          content_lines = []
+          j = i + 2
+          while j < @lines.length && !@lines[j].match?(/#{CLOSING_COMMENT}/)
+            content_lines << @lines[j]
+            j += 1
+          end
+          end_index = j
+
+          # Extract name and version from the content
+          joined = content_lines.map(&:strip).join(' ')
+          name = joined.match(/:(\w+),/)[1]
+          version_match = joined.match(/:version\s*=>\s*([^,}]+)/)
+          version = version_match[1].strip
+
+          result << "#{indent}#{method_name}(#{json_var}, :#{name}, version: #{version})"
+
+          # Skip rubocop:enable line immediately after END EXPANDED
+          i = end_index + 1
+          if i < @lines.length && @lines[i].match?(/#{ENABLE_RUBOCOP_COMMENT}/)
+            i += 1
+          end
+        else
+          result << line
+          i += 1
+        end
+      end
+
+      result.join("\n") + "\n"
+    end
+  end
+end

--- a/lib/schema_test/configuration.rb
+++ b/lib/schema_test/configuration.rb
@@ -13,10 +13,15 @@ module SchemaTest
     # as the Ruby PP output does not conform to rubocop's standards.
     attr_accessor :disable_rubocop
 
+    # Set to true to use pre-compiled JSON schema files for validation
+    # instead of inlining expanded schemas into test files.
+    attr_accessor :compiled
+
     def initialize
       @domain = 'example.com'
       @definition_paths = []
       @disable_rubocop = false
+      @compiled = false
     end
   end
 end

--- a/lib/schema_test/definition.rb
+++ b/lib/schema_test/definition.rb
@@ -16,6 +16,10 @@ module SchemaTest
       (@definitions || {}).dig(name, version)
     end
 
+    def self.all
+      (@definitions || {}).flat_map { |_name, versions| versions.values }
+    end
+
     def self.find!(name, version)
       found = find(name, version)
       raise SchemaTest::Error, "Could not find schema for #{name.inspect} (version: #{version.inspect})" unless found

--- a/lib/schema_test/definition.rb
+++ b/lib/schema_test/definition.rb
@@ -17,7 +17,7 @@ module SchemaTest
     end
 
     def self.all
-      (@definitions || {}).flat_map { |_name, versions| versions.values }
+      (@definitions || {}).values.flat_map(&:values)
     end
 
     def self.find!(name, version)

--- a/lib/schema_test/fingerprint_rewriter.rb
+++ b/lib/schema_test/fingerprint_rewriter.rb
@@ -4,6 +4,11 @@ module SchemaTest
   # compiled schema. This means a schema change shows up as a diff in
   # the test files themselves, pointing at exactly which API endpoints
   # changed, and lets the assertion verify the fingerprint at runtime.
+  #
+  # The call site reported at runtime is the line the call *starts* on,
+  # which for a multi-line call is the line with the opening paren. The
+  # rewriter therefore scans forward to find the matching closing paren
+  # before inserting or replacing the argument.
   class FingerprintRewriter
     FINGERPRINT_ARGUMENT = /fingerprint:\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s,)]+)/
 
@@ -13,24 +18,76 @@ module SchemaTest
     end
 
     def output
-      @line_indexes_with_fingerprints.each do |line_index, fingerprint|
-        line = @lines[line_index]
-        next unless line
-        @lines[line_index] = annotate(line, fingerprint)
+      @line_indexes_with_fingerprints.each do |start_index, fingerprint|
+        next unless @lines[start_index]
+        annotate_call(start_index, fingerprint)
       end
       @lines.join("\n") + "\n"
     end
 
     private
 
-    def annotate(line, fingerprint)
-      if line =~ FINGERPRINT_ARGUMENT
-        line.sub(FINGERPRINT_ARGUMENT, %(fingerprint: "#{fingerprint}"))
-      else
-        index = line.rindex(')')
-        return line unless index
-        %(#{line[0...index]}, fingerprint: "#{fingerprint}"#{line[index..-1]})
+    def annotate_call(start_index, fingerprint)
+      close = find_closing_paren(start_index)
+      return unless close
+      end_index, paren_column = close
+
+      # If the call already carries a fingerprint argument, replace it.
+      (start_index..end_index).each do |index|
+        if @lines[index] =~ FINGERPRINT_ARGUMENT
+          @lines[index] = @lines[index].sub(FINGERPRINT_ARGUMENT, %(fingerprint: "#{fingerprint}"))
+          return
+        end
       end
+
+      argument = %(fingerprint: "#{fingerprint}")
+      close_line = @lines[end_index]
+      before_paren = close_line[0...paren_column]
+
+      if before_paren.strip.empty?
+        # The closing paren is on its own line; append the argument to the
+        # last argument line so we don't leave a leading comma dangling.
+        insert_index = (start_index...end_index).to_a.reverse.find { |index| !@lines[index].strip.empty? } || start_index
+        @lines[insert_index] = "#{@lines[insert_index].sub(/,\s*\z/, '')}, #{argument}"
+      else
+        @lines[end_index] = "#{before_paren.sub(/,\s*\z/, '')}, #{argument}#{close_line[paren_column..-1]}"
+      end
+    end
+
+    # Finds the closing paren matching the first opening paren at or after
+    # the start line, returning [line_index, column] or nil. Skips parens
+    # inside string literals and trailing comments.
+    def find_closing_paren(start_index)
+      depth = 0
+      started = false
+      (start_index...@lines.length).each do |line_index|
+        line = @lines[line_index]
+        string_delimiter = nil
+        column = 0
+        while column < line.length
+          char = line[column]
+          if string_delimiter
+            if char == '\\'
+              column += 2
+              next
+            elsif char == string_delimiter
+              string_delimiter = nil
+            end
+          elsif char == '"' || char == "'"
+            string_delimiter = char
+          elsif char == '#'
+            break
+          elsif char == '('
+            depth += 1
+            started = true
+          elsif char == ')'
+            depth -= 1
+            return [line_index, column] if started && depth.zero?
+          end
+          column += 1
+        end
+      end
+      nil
     end
   end
 end

--- a/lib/schema_test/fingerprint_rewriter.rb
+++ b/lib/schema_test/fingerprint_rewriter.rb
@@ -35,12 +35,12 @@ module SchemaTest
       # If the call already carries a fingerprint argument, replace it.
       (start_index..end_index).each do |index|
         if @lines[index] =~ FINGERPRINT_ARGUMENT
-          @lines[index] = @lines[index].sub(FINGERPRINT_ARGUMENT, %(fingerprint: "#{fingerprint}"))
+          @lines[index] = @lines[index].sub(FINGERPRINT_ARGUMENT, "fingerprint: '#{fingerprint}'")
           return
         end
       end
 
-      argument = %(fingerprint: "#{fingerprint}")
+      argument = "fingerprint: '#{fingerprint}'"
       close_line = @lines[end_index]
       before_paren = close_line[0...paren_column]
 

--- a/lib/schema_test/fingerprint_rewriter.rb
+++ b/lib/schema_test/fingerprint_rewriter.rb
@@ -1,0 +1,36 @@
+module SchemaTest
+  # Rewrites `assert_valid_json_for_schema` calls in test files so that
+  # they carry an up-to-date `fingerprint:` argument matching the
+  # compiled schema. This means a schema change shows up as a diff in
+  # the test files themselves, pointing at exactly which API endpoints
+  # changed, and lets the assertion verify the fingerprint at runtime.
+  class FingerprintRewriter
+    FINGERPRINT_ARGUMENT = /fingerprint:\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s,)]+)/
+
+    def initialize(contents, line_indexes_with_fingerprints)
+      @lines = contents.split("\n")
+      @line_indexes_with_fingerprints = line_indexes_with_fingerprints
+    end
+
+    def output
+      @line_indexes_with_fingerprints.each do |line_index, fingerprint|
+        line = @lines[line_index]
+        next unless line
+        @lines[line_index] = annotate(line, fingerprint)
+      end
+      @lines.join("\n") + "\n"
+    end
+
+    private
+
+    def annotate(line, fingerprint)
+      if line =~ FINGERPRINT_ARGUMENT
+        line.sub(FINGERPRINT_ARGUMENT, %(fingerprint: "#{fingerprint}"))
+      else
+        index = line.rindex(')')
+        return line unless index
+        %(#{line[0...index]}, fingerprint: "#{fingerprint}"#{line[index..-1]})
+      end
+    end
+  end
+end

--- a/lib/schema_test/minitest.rb
+++ b/lib/schema_test/minitest.rb
@@ -3,23 +3,29 @@ require 'schema_test'
 module SchemaTest
   module Minitest
     def assert_valid_json_for_schema(json, name, arguments)
-      install_assert_api_expansion_hook
-
       version = arguments[:version]
-      schema = arguments[:schema]
 
-      definition = SchemaTest::Definition.find(name, version)
-      raise "Unknown definition #{name}, version: #{version}" unless definition.present?
+      if SchemaTest.configuration.compiled
+        schema = SchemaTest.load_compiled_schema(name, version: version)
+        assert_json_schema_validates_against(json, schema)
+      else
+        install_assert_api_expansion_hook
 
-      expected_schema = definition.as_json_schema
+        schema = arguments[:schema]
 
-      if schema != expected_schema && ENV['CI']
-        flunk "Outdated API schema assertion at #{caller[0]}"
+        definition = SchemaTest::Definition.find(name, version)
+        raise "Unknown definition #{name}, version: #{version}" unless definition.present?
+
+        expected_schema = definition.as_json_schema
+
+        if schema != expected_schema && ENV['CI']
+          flunk "Outdated API schema assertion at #{caller[0]}"
+        end
+
+        queue_write_expanded_assert_api_call(caller[0], __method__, name, version, definition.location, expected_schema)
+
+        assert_json_schema_validates_against(json, expected_schema)
       end
-
-      queue_write_expanded_assert_api_call(caller[0], __method__, name, version, definition.location, expected_schema)
-
-      assert_json_schema_validates_against(json, expected_schema)
     end
 
     def assert_json_schema_validates_against(json, schema)

--- a/lib/schema_test/minitest.rb
+++ b/lib/schema_test/minitest.rb
@@ -7,6 +7,17 @@ module SchemaTest
 
       if SchemaTest.configuration.compiled
         schema = SchemaTest.load_compiled_schema(name, version: version)
+        actual_fingerprint = SchemaTest.schema_fingerprint(schema)
+
+        if arguments[:fingerprint] != actual_fingerprint
+          if ENV['CI']
+            flunk "Schema fingerprint mismatch for #{name.inspect} (version: #{version.inspect}) at #{caller[0]}. The compiled schema has changed; run the tests locally to update the fingerprint."
+          else
+            install_fingerprint_rewrite_hook
+            queue_write_schema_fingerprint(caller[0], actual_fingerprint)
+          end
+        end
+
         assert_json_schema_validates_against(json, schema)
       else
         install_assert_api_expansion_hook
@@ -66,6 +77,30 @@ module SchemaTest
        raise "Error rewriting file" if new_contents.blank?
        File.open(file, 'w') { |f| f.puts new_contents }
      end
+    end
+
+    @@__schema_fingerprints = {}
+    @@__schema_fingerprint_hook_installed = false
+
+    def queue_write_schema_fingerprint(call_site, fingerprint)
+      file, line = call_site.split(':')
+      line_index = line.to_i.pred
+      @@__schema_fingerprints[file] ||= {}
+      @@__schema_fingerprints[file][line_index] = fingerprint
+    end
+
+    def install_fingerprint_rewrite_hook
+      return if @@__schema_fingerprint_hook_installed
+      at_exit { write_schema_fingerprints }
+      @@__schema_fingerprint_hook_installed = true
+    end
+
+    def write_schema_fingerprints
+      @@__schema_fingerprints.each do |file, line_indexes_with_fingerprints|
+        original_contents = File.read(file)
+        rewriter = SchemaTest::FingerprintRewriter.new(original_contents, line_indexes_with_fingerprints)
+        File.open(file, 'w') { |f| f.print rewriter.output }
+      end
     end
   end
 end

--- a/spec/integration/compiled_mode_spec.rb
+++ b/spec/integration/compiled_mode_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+require 'schema_test/minitest'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+
+# Exercises the real `assert_valid_json_for_schema` assertion in compiled
+# mode, end to end: a definition is compiled to disk, the assertion loads
+# the compiled schema, checks the fingerprint, and (locally) rewrites the
+# test file to carry an up-to-date `fingerprint:` argument.
+RSpec.describe 'compiled mode assertions' do
+  let(:definition_path) { Dir.mktmpdir }
+
+  # A stand-in for a Minitest::Test instance: it mixes in the assertion
+  # module and provides the `assert`/`flunk` hooks the module relies on.
+  let(:harness) do
+    Class.new do
+      include SchemaTest::Minitest
+
+      def assert(value, message = nil)
+        raise SchemaTest::Error, (message || 'assertion failed') unless value
+      end
+
+      def flunk(message = nil)
+        raise SchemaTest::Error, "flunk: #{message}"
+      end
+    end.new
+  end
+
+  before do
+    # The rewrite queue/hook live in module class variables; reset them so
+    # examples don't leak into each other.
+    SchemaTest::Minitest.class_variable_set(:@@__schema_fingerprints, {})
+    SchemaTest::Minitest.class_variable_set(:@@__schema_fingerprint_hook_installed, false)
+
+    SchemaTest.configure do |config|
+      config.domain = 'example.com'
+      config.definition_paths << definition_path
+      config.compiled = true
+    end
+
+    SchemaTest::Definition.new(:widget, version: 1, location: 'api/widget.rb:1', properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+    SchemaTest.compile!
+  end
+
+  after do
+    FileUtils.remove_entry(definition_path)
+  end
+
+  let(:expected_fingerprint) do
+    SchemaTest.schema_fingerprint(SchemaTest.load_compiled_schema(:widget, version: 1))
+  end
+
+  # Evaluates the test file so that `caller` inside the assertion resolves
+  # to the file/line we wrote, exactly as it would in a real test run.
+  # `at_exit` is stubbed so the deferred rewrite can be triggered inline
+  # (and returned) instead of running when the rspec process exits.
+  def run_test_file(contents)
+    test_file = File.join(definition_path, 'widget_test.rb')
+    File.write(test_file, contents)
+
+    deferred_rewrite = nil
+    allow(harness).to receive(:at_exit) { |&block| deferred_rewrite = block }
+
+    json = { 'name' => 'thing' }
+    eval(File.read(test_file), binding, test_file) # rubocop:disable Security/Eval
+
+    [test_file, deferred_rewrite]
+  end
+
+  def without_ci
+    original = ENV['CI']
+    ENV.delete('CI')
+    yield
+  ensure
+    original.nil? ? ENV.delete('CI') : ENV['CI'] = original
+  end
+
+  def with_ci
+    original = ENV['CI']
+    ENV['CI'] = '1'
+    yield
+  ensure
+    original.nil? ? ENV.delete('CI') : ENV['CI'] = original
+  end
+
+  it 'rewrites the test file with the compiled schema fingerprint when it is missing' do
+    without_ci do
+      test_file, deferred_rewrite = run_test_file(<<~RUBY)
+        # widget endpoint
+        harness.assert_valid_json_for_schema(json, :widget, version: 1)
+      RUBY
+
+      expect(deferred_rewrite).not_to be_nil
+      deferred_rewrite.call
+
+      expect(File.read(test_file)).to eq(<<~RUBY)
+        # widget endpoint
+        harness.assert_valid_json_for_schema(json, :widget, version: 1, fingerprint: '#{expected_fingerprint}')
+      RUBY
+    end
+  end
+
+  it 'leaves the test file untouched when the fingerprint already matches' do
+    without_ci do
+      contents = <<~RUBY
+        # widget endpoint
+        harness.assert_valid_json_for_schema(json, :widget, version: 1, fingerprint: '#{expected_fingerprint}')
+      RUBY
+
+      test_file, deferred_rewrite = run_test_file(contents)
+
+      expect(deferred_rewrite).to be_nil
+      expect(File.read(test_file)).to eq(contents)
+    end
+  end
+
+  it 'updates a stale fingerprint in the test file' do
+    without_ci do
+      test_file, deferred_rewrite = run_test_file(<<~RUBY)
+        harness.assert_valid_json_for_schema(json, :widget, version: 1, fingerprint: 'stalevalue00')
+      RUBY
+
+      deferred_rewrite.call
+
+      expect(File.read(test_file)).to eq(<<~RUBY)
+        harness.assert_valid_json_for_schema(json, :widget, version: 1, fingerprint: '#{expected_fingerprint}')
+      RUBY
+    end
+  end
+
+  it 'flunks instead of rewriting when the fingerprint is stale in CI' do
+    with_ci do
+      expect {
+        run_test_file(<<~RUBY)
+          harness.assert_valid_json_for_schema(json, :widget, version: 1, fingerprint: 'stalevalue00')
+        RUBY
+      }.to raise_error(SchemaTest::Error, /flunk: Schema fingerprint mismatch/)
+    end
+  end
+
+  it 'fails the assertion when the JSON does not match the compiled schema' do
+    without_ci do
+      test_file = File.join(definition_path, 'widget_test.rb')
+      File.write(test_file, "harness.assert_valid_json_for_schema(bad_json, :widget, version: 1, fingerprint: '#{expected_fingerprint}')\n")
+      allow(harness).to receive(:at_exit)
+
+      bad_json = { 'name' => 123 }
+      expect {
+        eval(File.read(test_file), binding, test_file) # rubocop:disable Security/Eval
+      }.to raise_error(SchemaTest::Error, /JSON did not pass schema/)
+    end
+  end
+end

--- a/spec/schema_test/collapser_spec.rb
+++ b/spec/schema_test/collapser_spec.rb
@@ -1,0 +1,259 @@
+require 'spec_helper'
+require 'schema_test/collapser'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe SchemaTest::Collapser do
+  it 'collapses a simple expanded assertion' do
+    input = <<~FILE
+      line 1
+      line 2
+      assert_schema( # EXPANDED from path/schema.rb:1
+        json,
+        :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+      ) # END EXPANDED
+      line 3
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      line 1
+      line 2
+      assert_schema(json, :arg1, version: :arg2)
+      line 3
+    FILE
+  end
+
+  it 'preserves the json variable name' do
+    input = <<~FILE
+      assert_schema( # EXPANDED from path/schema.rb:1
+        some_other_json_argument,
+        :thing, {:version=>1, :schema=>:expanded_contents}
+      ) # END EXPANDED
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_schema(some_other_json_argument, :thing, version: 1)
+    FILE
+  end
+
+  it 'preserves indentation' do
+    input = <<~FILE
+      line 1
+          assert_schema( # EXPANDED from path/schema.rb:1
+            json,
+            :user, {:version=>2, :schema=>:expanded_contents}
+          ) # END EXPANDED
+      line 2
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      line 1
+          assert_schema(json, :user, version: 2)
+      line 2
+    FILE
+  end
+
+  it 'collapses multiple expanded assertions in the same file' do
+    input = <<~FILE
+      assert_schema( # EXPANDED from path/schema.rb:1
+        json,
+        :user, {:version=>1, :schema=>:stuff}
+      ) # END EXPANDED
+      some other line
+      assert_schema( # EXPANDED from path/other.rb:5
+        other_json,
+        :comment, {:version=>3, :schema=>:other_stuff}
+      ) # END EXPANDED
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_schema(json, :user, version: 1)
+      some other line
+      assert_schema(other_json, :comment, version: 3)
+    FILE
+  end
+
+  it 'collapses assertions with multi-line pretty-printed schemas' do
+    input = <<~FILE
+      assert_schema( # EXPANDED from path/schema.rb:1
+        json,
+        :arg1,
+         {:version=>:arg2,
+          :schema=>
+           {:thing=>123,
+            :other_thing=>
+             {:inner_thing=>[1, 2, 3, 4],
+              :value=>"stuff",
+              :boolean_value=>true,
+              :float_value=>1.23}}}
+      ) # END EXPANDED
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_schema(json, :arg1, version: :arg2)
+    FILE
+  end
+
+  it 'strips rubocop:disable/enable lines around expanded blocks' do
+    input = <<~FILE
+      line 1
+      # rubocop:disable all
+      assert_schema( # EXPANDED from path/schema.rb:1
+        json,
+        :user, {:version=>1, :schema=>:stuff}
+      ) # END EXPANDED
+      # rubocop:enable all
+      line 2
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      line 1
+      assert_schema(json, :user, version: 1)
+      line 2
+    FILE
+  end
+
+  it 'handles different method names' do
+    input = <<~FILE
+      assert_valid_json_for_schema( # EXPANDED from path/schema.rb:1
+        response_json,
+        :widget, {:version=>4, :schema=>:stuff}
+      ) # END EXPANDED
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_valid_json_for_schema(response_json, :widget, version: 4)
+    FILE
+  end
+
+  it 'leaves non-expanded lines untouched' do
+    input = <<~FILE
+      line 1
+      assert_schema(json, :user, version: 1)
+      line 3
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      line 1
+      assert_schema(json, :user, version: 1)
+      line 3
+    FILE
+  end
+
+  it 'handles a mix of expanded and non-expanded assertions' do
+    input = <<~FILE
+      assert_schema(json, :thing, version: 1)
+      assert_schema( # EXPANDED from path/schema.rb:5
+        other_json,
+        :widget, {:version=>2, :schema=>:stuff}
+      ) # END EXPANDED
+      more code
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_schema(json, :thing, version: 1)
+      assert_schema(other_json, :widget, version: 2)
+      more code
+    FILE
+  end
+
+  it 'handles indented rubocop blocks' do
+    input = <<~FILE
+      line 1
+        # rubocop:disable all
+        assert_schema( # EXPANDED from path/schema.rb:1
+          json,
+          :user, {:version=>1, :schema=>:stuff}
+        ) # END EXPANDED
+        # rubocop:enable all
+      line 2
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      line 1
+        assert_schema(json, :user, version: 1)
+      line 2
+    FILE
+  end
+
+  it 'handles only rubocop:enable without rubocop:disable' do
+    input = <<~FILE
+      assert_schema( # EXPANDED from path/schema.rb:1
+        json,
+        :user, {:version=>1, :schema=>:stuff}
+      ) # END EXPANDED
+      # rubocop:enable all
+      line 2
+    FILE
+
+    expect(described_class.new(input).output).to eq(<<~FILE)
+      assert_schema(json, :user, version: 1)
+      line 2
+    FILE
+  end
+end
+
+RSpec.describe 'SchemaTest.collapse!' do
+  let(:tmpdir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  it 'collapses expanded assertions in the given files' do
+    test_file = File.join(tmpdir, 'widget_test.rb')
+    File.write(test_file, <<~FILE)
+      test 'it works' do
+        assert_schema( # EXPANDED from schema.rb:1
+          json,
+          :widget, {:version=>1, :schema=>:stuff}
+        ) # END EXPANDED
+      end
+    FILE
+
+    SchemaTest.collapse!(test_file)
+
+    expect(File.read(test_file)).to eq(<<~FILE)
+      test 'it works' do
+        assert_schema(json, :widget, version: 1)
+      end
+    FILE
+  end
+
+  it 'skips files without expanded assertions' do
+    test_file = File.join(tmpdir, 'clean_test.rb')
+    original = <<~FILE
+      test 'it works' do
+        assert_schema(json, :widget, version: 1)
+      end
+    FILE
+    File.write(test_file, original)
+
+    SchemaTest.collapse!(test_file)
+
+    expect(File.read(test_file)).to eq(original)
+  end
+
+  it 'globs for ruby files when given a directory' do
+    subdir = File.join(tmpdir, 'controllers')
+    FileUtils.mkdir_p(subdir)
+
+    test_file = File.join(subdir, 'users_test.rb')
+    File.write(test_file, <<~FILE)
+      assert_schema( # EXPANDED from schema.rb:1
+        json,
+        :user, {:version=>1, :schema=>:stuff}
+      ) # END EXPANDED
+    FILE
+
+    not_ruby = File.join(subdir, 'notes.txt')
+    File.write(not_ruby, "just a text file with # EXPANDED in it\n")
+
+    SchemaTest.collapse!(tmpdir)
+
+    expect(File.read(test_file)).to eq(<<~FILE)
+      assert_schema(json, :user, version: 1)
+    FILE
+    expect(File.read(not_ruby)).to eq("just a text file with # EXPANDED in it\n")
+  end
+end

--- a/spec/schema_test/compile_spec.rb
+++ b/spec/schema_test/compile_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+
+RSpec.describe 'SchemaTest.compile!' do
+  let(:definition_path) { Dir.mktmpdir }
+  let(:compiled_path) { File.join(definition_path, 'compiled') }
+
+  before do
+    SchemaTest.configure do |config|
+      config.definition_paths << definition_path
+    end
+  end
+
+  after do
+    FileUtils.remove_entry(definition_path)
+  end
+
+  it 'creates a compiled directory within the definition path' do
+    SchemaTest::Definition.new(:thing, properties: [SchemaTest::Property::String.new(:name)])
+
+    SchemaTest.compile!
+
+    expect(Dir.exist?(compiled_path)).to be true
+  end
+
+  it 'writes each definition as a JSON file' do
+    SchemaTest::Definition.new(:widget, properties: [
+      SchemaTest::Property::String.new(:name),
+      SchemaTest::Property::Integer.new(:count)
+    ])
+
+    SchemaTest.compile!
+
+    json_path = File.join(compiled_path, 'widget.json')
+    expect(File.exist?(json_path)).to be true
+
+    schema = JSON.parse(File.read(json_path))
+    expect(schema['$schema']).to eq 'http://json-schema.org/draft-07/schema#'
+    expect(schema['title']).to eq 'widget'
+    expect(schema['properties']).to have_key('name')
+    expect(schema['properties']).to have_key('count')
+  end
+
+  it 'includes the version in the filename for versioned definitions' do
+    SchemaTest::Definition.new(:gadget, version: 1, properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+
+    SchemaTest::Definition.new(:gadget, version: 2, properties: [
+      SchemaTest::Property::String.new(:name),
+      SchemaTest::Property::String.new(:description)
+    ])
+
+    SchemaTest.compile!
+
+    v1_schema = JSON.parse(File.read(File.join(compiled_path, 'gadget.v1.json')))
+    expect(v1_schema['title']).to eq 'gadget'
+    expect(v1_schema['properties'].keys).to eq ['name']
+
+    v2_schema = JSON.parse(File.read(File.join(compiled_path, 'gadget.v2.json')))
+    expect(v2_schema['title']).to eq 'gadget'
+    expect(v2_schema['properties'].keys).to eq ['name', 'description']
+  end
+
+  it 'writes pretty-printed JSON with a trailing newline' do
+    SchemaTest::Definition.new(:item, properties: [SchemaTest::Property::String.new(:name)])
+
+    SchemaTest.compile!
+
+    content = File.read(File.join(compiled_path, 'item.json'))
+    expect(content).to end_with("\n")
+    expect(content).to include("\n  ")
+  end
+
+  it 'compiles collection definitions' do
+    SchemaTest::Definition.new(:thing, properties: [SchemaTest::Property::String.new(:name)])
+    SchemaTest::Collection.new(:things, :thing)
+
+    SchemaTest.compile!
+
+    expect(File.exist?(File.join(compiled_path, 'thing.json'))).to be true
+    expect(File.exist?(File.join(compiled_path, 'things.json'))).to be true
+
+    collection_schema = JSON.parse(File.read(File.join(compiled_path, 'things.json')))
+    expect(collection_schema['type']).to eq 'array'
+  end
+end
+
+RSpec.describe 'SchemaTest.load_compiled_schema' do
+  let(:definition_path) { Dir.mktmpdir }
+  let(:compiled_path) { File.join(definition_path, 'compiled') }
+
+  before do
+    SchemaTest.configure do |config|
+      config.definition_paths << definition_path
+    end
+  end
+
+  after do
+    FileUtils.remove_entry(definition_path)
+  end
+
+  it 'loads an unversioned compiled schema from disk' do
+    SchemaTest::Definition.new(:widget, properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+    SchemaTest.compile!
+
+    schema = SchemaTest.load_compiled_schema(:widget)
+    expect(schema['title']).to eq 'widget'
+    expect(schema['properties']).to have_key('name')
+  end
+
+  it 'loads a versioned compiled schema from disk' do
+    SchemaTest::Definition.new(:gadget, version: 2, properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+    SchemaTest.compile!
+
+    schema = SchemaTest.load_compiled_schema(:gadget, version: 2)
+    expect(schema['title']).to eq 'gadget'
+    expect(schema['$id']).to include('v2')
+  end
+
+  it 'raises an error when the compiled schema is not found' do
+    expect {
+      SchemaTest.load_compiled_schema(:nonexistent, version: 1)
+    }.to raise_error(SchemaTest::Error, /Could not find compiled schema/)
+  end
+end
+
+RSpec.describe 'compiled configuration' do
+  it 'defaults to false' do
+    expect(SchemaTest.configuration.compiled).to be false
+  end
+
+  it 'can be toggled on' do
+    SchemaTest.configure do |config|
+      config.compiled = true
+    end
+    expect(SchemaTest.configuration.compiled).to be true
+  end
+end

--- a/spec/schema_test/compile_spec.rb
+++ b/spec/schema_test/compile_spec.rb
@@ -73,6 +73,39 @@ RSpec.describe 'SchemaTest.compile!' do
     expect(content).to include("\n  ")
   end
 
+  it 'mirrors the layout of the original definition files' do
+    SchemaTest::Definition.new(:film, location: 'api/v3/film.rb:5', properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+
+    SchemaTest.compile!
+
+    json_path = File.join(compiled_path, 'api', 'v3', 'film.json')
+    expect(File.exist?(json_path)).to be true
+
+    schema = JSON.parse(File.read(json_path))
+    expect(schema['title']).to eq 'film'
+  end
+
+  it 'mirrors the layout for versioned definitions' do
+    SchemaTest::Definition.new(:film, version: 2, location: 'api/v3/film.rb:5', properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+
+    SchemaTest.compile!
+
+    json_path = File.join(compiled_path, 'api', 'v3', 'film.v2.json')
+    expect(File.exist?(json_path)).to be true
+  end
+
+  it 'writes definitions without a location to the root of the compiled directory' do
+    SchemaTest::Definition.new(:loose, properties: [SchemaTest::Property::String.new(:name)])
+
+    SchemaTest.compile!
+
+    expect(File.exist?(File.join(compiled_path, 'loose.json'))).to be true
+  end
+
   it 'compiles collection definitions' do
     SchemaTest::Definition.new(:thing, properties: [SchemaTest::Property::String.new(:name)])
     SchemaTest::Collection.new(:things, :thing)
@@ -84,6 +117,38 @@ RSpec.describe 'SchemaTest.compile!' do
 
     collection_schema = JSON.parse(File.read(File.join(compiled_path, 'things.json')))
     expect(collection_schema['type']).to eq 'array'
+  end
+end
+
+RSpec.describe 'SchemaTest.compile! with multiple definition paths' do
+  let(:path_a) { Dir.mktmpdir }
+  let(:path_b) { Dir.mktmpdir }
+
+  before do
+    SchemaTest.configure do |config|
+      config.definition_paths << path_a
+      config.definition_paths << path_b
+    end
+  end
+
+  after do
+    FileUtils.remove_entry(path_a)
+    FileUtils.remove_entry(path_b)
+  end
+
+  it 'writes each schema once, into the compiled directory of its owning path' do
+    FileUtils.mkdir_p(File.join(path_a, 'api', 'v3'))
+    File.write(File.join(path_a, 'api', 'v3', 'film.rb'), <<~RUBY)
+      SchemaTest.define :film do
+        string :name
+      end
+    RUBY
+
+    SchemaTest.compile!
+
+    expect(File.exist?(File.join(path_a, 'compiled', 'api', 'v3', 'film.json'))).to be true
+    expect(File.exist?(File.join(path_b, 'compiled', 'api', 'v3', 'film.json'))).to be false
+    expect(Dir.exist?(File.join(path_b, 'compiled'))).to be false
   end
 end
 
@@ -121,6 +186,17 @@ RSpec.describe 'SchemaTest.load_compiled_schema' do
     schema = SchemaTest.load_compiled_schema(:gadget, version: 2)
     expect(schema['title']).to eq 'gadget'
     expect(schema['$id']).to include('v2')
+  end
+
+  it 'loads a compiled schema nested in a mirrored subdirectory' do
+    SchemaTest::Definition.new(:film, location: 'api/v3/film.rb:5', properties: [
+      SchemaTest::Property::String.new(:name)
+    ])
+    SchemaTest.compile!
+
+    schema = SchemaTest.load_compiled_schema(:film)
+    expect(schema['title']).to eq 'film'
+    expect(schema['properties']).to have_key('name')
   end
 
   it 'raises an error when the compiled schema is not found' do

--- a/spec/schema_test/fingerprint_spec.rb
+++ b/spec/schema_test/fingerprint_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe 'SchemaTest.schema_fingerprint' do
+  it 'is stable for the same schema' do
+    schema = { 'title' => 'film', 'properties' => { 'name' => { 'type' => 'string' } } }
+    expect(SchemaTest.schema_fingerprint(schema)).to eq SchemaTest.schema_fingerprint(schema)
+  end
+
+  it 'changes when the schema changes' do
+    one = { 'title' => 'film', 'properties' => { 'name' => { 'type' => 'string' } } }
+    two = { 'title' => 'film', 'properties' => { 'name' => { 'type' => 'integer' } } }
+    expect(SchemaTest.schema_fingerprint(one)).not_to eq SchemaTest.schema_fingerprint(two)
+  end
+
+  it 'is a hex SHA-256 digest' do
+    fingerprint = SchemaTest.schema_fingerprint({ 'title' => 'film' })
+    expect(fingerprint).to match(/\A[0-9a-f]{64}\z/)
+  end
+end
+
+RSpec.describe SchemaTest::FingerprintRewriter do
+  def rewrite(contents, fingerprints)
+    described_class.new(contents, fingerprints).output
+  end
+
+  it 'inserts a fingerprint argument into an assertion that has none' do
+    contents = "assert_valid_json_for_schema(json, :film, version: 1)\n"
+    output = rewrite(contents, { 0 => 'abc123' })
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "abc123")\n)
+  end
+
+  it 'replaces an existing fingerprint argument' do
+    contents = %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "old")\n)
+    output = rewrite(contents, { 0 => 'new' })
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "new")\n)
+  end
+
+  it 'inserts before the closing paren of the call, not a nested one' do
+    contents = "assert_valid_json_for_schema(JSON.parse(body), :film, version: 1)\n"
+    output = rewrite(contents, { 0 => 'abc' })
+    expect(output).to eq %(assert_valid_json_for_schema(JSON.parse(body), :film, version: 1, fingerprint: "abc")\n)
+  end
+
+  it 'preserves a trailing comment after the call' do
+    contents = "assert_valid_json_for_schema(json, :film) # a note\n"
+    output = rewrite(contents, { 0 => 'abc' })
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, fingerprint: "abc") # a note\n)
+  end
+
+  it 'only rewrites the targeted lines' do
+    contents = "line one\nassert_valid_json_for_schema(json, :film)\nline three\n"
+    output = rewrite(contents, { 1 => 'abc' })
+    expect(output).to eq "line one\nassert_valid_json_for_schema(json, :film, fingerprint: \"abc\")\nline three\n"
+  end
+end

--- a/spec/schema_test/fingerprint_spec.rb
+++ b/spec/schema_test/fingerprint_spec.rb
@@ -32,31 +32,31 @@ RSpec.describe SchemaTest::FingerprintRewriter do
   it 'inserts a fingerprint argument into an assertion that has none' do
     contents = "assert_valid_json_for_schema(json, :film, version: 1)\n"
     output = rewrite(contents, { 0 => 'abc123' })
-    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "abc123")\n)
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: 'abc123')\n)
   end
 
-  it 'replaces an existing fingerprint argument' do
+  it 'replaces an existing fingerprint argument, normalising to single quotes' do
     contents = %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "old")\n)
     output = rewrite(contents, { 0 => 'new' })
-    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: "new")\n)
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, version: 1, fingerprint: 'new')\n)
   end
 
   it 'inserts before the closing paren of the call, not a nested one' do
     contents = "assert_valid_json_for_schema(JSON.parse(body), :film, version: 1)\n"
     output = rewrite(contents, { 0 => 'abc' })
-    expect(output).to eq %(assert_valid_json_for_schema(JSON.parse(body), :film, version: 1, fingerprint: "abc")\n)
+    expect(output).to eq %(assert_valid_json_for_schema(JSON.parse(body), :film, version: 1, fingerprint: 'abc')\n)
   end
 
   it 'preserves a trailing comment after the call' do
     contents = "assert_valid_json_for_schema(json, :film) # a note\n"
     output = rewrite(contents, { 0 => 'abc' })
-    expect(output).to eq %(assert_valid_json_for_schema(json, :film, fingerprint: "abc") # a note\n)
+    expect(output).to eq %(assert_valid_json_for_schema(json, :film, fingerprint: 'abc') # a note\n)
   end
 
   it 'only rewrites the targeted lines' do
     contents = "line one\nassert_valid_json_for_schema(json, :film)\nline three\n"
     output = rewrite(contents, { 1 => 'abc' })
-    expect(output).to eq "line one\nassert_valid_json_for_schema(json, :film, fingerprint: \"abc\")\nline three\n"
+    expect(output).to eq "line one\nassert_valid_json_for_schema(json, :film, fingerprint: 'abc')\nline three\n"
   end
 
   it 'inserts into a multi-line call where the start line has no closing paren' do
@@ -72,7 +72,7 @@ RSpec.describe SchemaTest::FingerprintRewriter do
       assert_valid_json_for_schema(
         json,
         :film,
-        version: 1, fingerprint: "abc"
+        version: 1, fingerprint: 'abc'
       )
     RUBY
   end
@@ -83,7 +83,7 @@ RSpec.describe SchemaTest::FingerprintRewriter do
         json,
         :film,
         version: 1,
-        fingerprint: "old"
+        fingerprint: 'old'
       )
     RUBY
     output = rewrite(contents, { 0 => 'new' })
@@ -92,7 +92,7 @@ RSpec.describe SchemaTest::FingerprintRewriter do
         json,
         :film,
         version: 1,
-        fingerprint: "new"
+        fingerprint: 'new'
       )
     RUBY
   end
@@ -110,7 +110,7 @@ RSpec.describe SchemaTest::FingerprintRewriter do
       assert_valid_json_for_schema(
         json,
         :film,
-        version: 1, fingerprint: "abc"
+        version: 1, fingerprint: 'abc'
       )
     RUBY
   end

--- a/spec/schema_test/fingerprint_spec.rb
+++ b/spec/schema_test/fingerprint_spec.rb
@@ -52,4 +52,60 @@ RSpec.describe SchemaTest::FingerprintRewriter do
     output = rewrite(contents, { 1 => 'abc' })
     expect(output).to eq "line one\nassert_valid_json_for_schema(json, :film, fingerprint: \"abc\")\nline three\n"
   end
+
+  it 'inserts into a multi-line call where the start line has no closing paren' do
+    contents = <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1
+      )
+    RUBY
+    output = rewrite(contents, { 0 => 'abc' })
+    expect(output).to eq <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1, fingerprint: "abc"
+      )
+    RUBY
+  end
+
+  it 'replaces an existing fingerprint in a multi-line call' do
+    contents = <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1,
+        fingerprint: "old"
+      )
+    RUBY
+    output = rewrite(contents, { 0 => 'new' })
+    expect(output).to eq <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1,
+        fingerprint: "new"
+      )
+    RUBY
+  end
+
+  it 'handles a trailing comma on the last argument of a multi-line call' do
+    contents = <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1,
+      )
+    RUBY
+    output = rewrite(contents, { 0 => 'abc' })
+    expect(output).to eq <<~RUBY
+      assert_valid_json_for_schema(
+        json,
+        :film,
+        version: 1, fingerprint: "abc"
+      )
+    RUBY
+  end
 end

--- a/spec/schema_test/fingerprint_spec.rb
+++ b/spec/schema_test/fingerprint_spec.rb
@@ -12,9 +12,15 @@ RSpec.describe 'SchemaTest.schema_fingerprint' do
     expect(SchemaTest.schema_fingerprint(one)).not_to eq SchemaTest.schema_fingerprint(two)
   end
 
-  it 'is a hex SHA-256 digest' do
+  it 'is a short hex digest prefix' do
     fingerprint = SchemaTest.schema_fingerprint({ 'title' => 'film' })
-    expect(fingerprint).to match(/\A[0-9a-f]{64}\z/)
+    expect(fingerprint).to match(/\A[0-9a-f]{#{SchemaTest::FINGERPRINT_LENGTH}}\z/)
+  end
+
+  it 'is a prefix of the full SHA-256 digest' do
+    schema = { 'title' => 'film' }
+    full = Digest::SHA256.hexdigest(JSON.generate(schema))
+    expect(SchemaTest.schema_fingerprint(schema)).to eq full[0, SchemaTest::FINGERPRINT_LENGTH]
   end
 end
 


### PR DESCRIPTION
Adds a `compiled` configuration option that changes how schema assertions work. When enabled, `SchemaTest.compile!` writes every registered definition as a standalone JSON Schema file into a
`compiled/` directory within each definition path. 

The minitest assertion then validates against these pre-compiled files directly, skipping the test-file rewriting behaviour entirely.

Also adds a `collapse!` method to programmatically rewrite expanded assertions back into their compact form.