### PR TITLE
Deduplicate schema expansion

### DIFF
--- a/lib/schema_test/rewriter.rb
+++ b/lib/schema_test/rewriter.rb
@@ -41,7 +41,7 @@ module SchemaTest
 
         if expanded_locations[location]
           short_form = (' ' * start_indent) +
-            "#{method}(#{json_variable_name}, :#{name}, version: :#{version}) # schema from #{location}"
+            "#{method}(#{json_variable_name}, #{name.inspect}, version: #{version.inspect}) # schema from #{location}"
           method_string = [short_form]
         else
           expanded_locations[location] = true

--- a/lib/schema_test/rewriter.rb
+++ b/lib/schema_test/rewriter.rb
@@ -17,6 +17,7 @@ module SchemaTest
 
     def output
       current_offset = 0
+      expanded_locations = {}
       line_indexes_with_schemas.sort_by { |(line,_)| line }.each do |index, method, name, version, location, expected_schema|
         start_index = index + current_offset
         if lines[start_index - 1].match?(/#{DISABLE_RUBOCOP_COMMENT}/)
@@ -38,19 +39,27 @@ module SchemaTest
         start_indent = lines[start_index].match(/\A(\s*)/)[0].length
         (end_index - start_index + 1).times { |i| lines.delete_at(start_index) }
 
-        output = StringIO.new
-        PP.pp([name, version: version, schema: expected_schema], output)
-        output.rewind
-        expanded_schema_lines = output.read.strip.gsub(/\A\[/, '').gsub(/\]\z/, '').split("\n")
-        expanded_schema_lines.unshift(json_variable_name + ',')
+        if expanded_locations[location]
+          short_form = (' ' * start_indent) +
+            "#{method}(#{json_variable_name}, :#{name}, version: :#{version}) # schema from #{location}"
+          method_string = [short_form]
+        else
+          expanded_locations[location] = true
 
-        method_string = [
-          disable_rubocop ? (' ' * start_indent) + DISABLE_RUBOCOP_COMMENT : nil,
-          (' ' * start_indent) + method.to_s + "( #{OPENING_COMMENT} from #{location}",
-          *expanded_schema_lines.map { |line| (' ' * (start_indent + 2)) + line },
-          (' ' * start_indent) + ") #{CLOSING_COMMENT}",
-          disable_rubocop ? (' ' * start_indent) + ENABLE_RUBOCOP_COMMENT: nil,
-        ].compact
+          output = StringIO.new
+          PP.pp([name, version: version, schema: expected_schema], output)
+          output.rewind
+          expanded_schema_lines = output.read.strip.gsub(/\A\[/, '').gsub(/\]\z/, '').split("\n")
+          expanded_schema_lines.unshift(json_variable_name + ',')
+
+          method_string = [
+            disable_rubocop ? (' ' * start_indent) + DISABLE_RUBOCOP_COMMENT : nil,
+            (' ' * start_indent) + method.to_s + "( #{OPENING_COMMENT} from #{location}",
+            *expanded_schema_lines.map { |line| (' ' * (start_indent + 2)) + line },
+            (' ' * start_indent) + ") #{CLOSING_COMMENT}",
+            disable_rubocop ? (' ' * start_indent) + ENABLE_RUBOCOP_COMMENT: nil,
+          ].compact
+        end
 
         method_string.reverse.each { |line| lines.insert(start_index, line) }
 

--- a/spec/schema_test/rewriter_spec.rb
+++ b/spec/schema_test/rewriter_spec.rb
@@ -678,6 +678,31 @@ line 11
       FILE
     end
 
+    it 'correctly outputs name and version arguments in the short form' do
+      input = <<~FILE
+line 1
+assert_schema(json, arg1, version: arg2)
+line 3
+assert_schema(other_json, arg1, version: arg2)
+line 5
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :users, 2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :users, 2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :users, {:version=>2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 3
+assert_schema(other_json, :users, version: 2) # schema from path/schema.rb:1
+line 5
+      FILE
+    end
+
     it 'is idempotent when re-processing already-deduplicated output' do
       input = <<~FILE
 line 1

--- a/spec/schema_test/rewriter_spec.rb
+++ b/spec/schema_test/rewriter_spec.rb
@@ -138,10 +138,7 @@ assert_schema( # EXPANDED from path/schema.rb:1
 ) # END EXPANDED
 line 3
 line 4
-assert_other_schema( # EXPANDED from path/schema.rb:1
-  other_json,
-  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
-) # END EXPANDED
+assert_other_schema(other_json, :arg3, version: :arg4) # schema from path/schema.rb:1
 line 5
      FILE
   end
@@ -501,6 +498,213 @@ assert_schema( # EXPANDED from path/other_schema.rb:10
   :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
 ) # END EXPANDED
     FILE
+  end
+
+  context 'deduplication of repeated definition locations' do
+    it 'does not expand the schema for the second use of the same definition location' do
+      input = <<~FILE
+line 1
+assert_schema(json, arg1, version: arg2)
+line 3
+assert_schema(other_json, arg1, version: arg2)
+line 5
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 3
+assert_schema(other_json, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 5
+      FILE
+    end
+
+    it 'does not expand the schema for third or subsequent uses' do
+      input = <<~FILE
+line 1
+assert_schema(json1, arg1, version: arg2)
+line 3
+assert_schema(json2, arg1, version: arg2)
+line 5
+assert_schema(json3, arg1, version: arg2)
+line 7
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [5, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json1,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 3
+assert_schema(json2, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 5
+assert_schema(json3, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 7
+      FILE
+    end
+
+    it 'still expands each unique definition location' do
+      input = <<~FILE
+line 1
+assert_schema(json, arg1, version: arg2)
+line 3
+assert_schema(json, arg3, version: arg4)
+line 5
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:5', :expanded_contents2]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 3
+assert_schema( # EXPANDED from path/other_schema.rb:5
+  json,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+line 5
+      FILE
+    end
+
+    it 'expands each unique location once when mixed with duplicates' do
+      input = <<~FILE
+line 1
+assert_schema(json1, arg1, version: arg2)
+line 3
+assert_schema(json2, arg3, version: arg4)
+line 5
+assert_schema(json3, arg1, version: arg2)
+line 7
+assert_schema(json4, arg3, version: arg4)
+line 9
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:5', :expanded_contents2],
+        [5, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [7, :assert_schema, :arg3, :arg4, 'path/other_schema.rb:5', :expanded_contents2]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json1,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 3
+assert_schema( # EXPANDED from path/other_schema.rb:5
+  json2,
+  :arg3, {:version=>:arg4, :schema=>:expanded_contents2}
+) # END EXPANDED
+line 5
+assert_schema(json3, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 7
+assert_schema(json4, :arg3, version: :arg4) # schema from path/other_schema.rb:5
+line 9
+      FILE
+    end
+
+    it 'preserves indentation for non-expanded occurrences' do
+      input = <<~FILE
+line 1
+  assert_schema(json, arg1, version: arg2)
+line 3
+  assert_schema(other_json, arg1, version: arg2)
+line 5
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [3, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+  assert_schema( # EXPANDED from path/schema.rb:1
+    json,
+    :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+  ) # END EXPANDED
+line 3
+  assert_schema(other_json, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 5
+      FILE
+    end
+
+    it 'rewrites a previously-expanded duplicate back to the short form' do
+      input = <<~FILE
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 6
+assert_schema( # EXPANDED from path/schema.rb:1
+  other_json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 11
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [6, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 6
+assert_schema(other_json, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 11
+      FILE
+    end
+
+    it 'is idempotent when re-processing already-deduplicated output' do
+      input = <<~FILE
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 6
+assert_schema(other_json, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 8
+      FILE
+
+      rewriter = described_class.new(input, [
+        [1, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents],
+        [6, :assert_schema, :arg1, :arg2, 'path/schema.rb:1', :expanded_contents]
+      ])
+      expect(rewriter.output).to eq(<<~FILE)
+line 1
+assert_schema( # EXPANDED from path/schema.rb:1
+  json,
+  :arg1, {:version=>:arg2, :schema=>:expanded_contents}
+) # END EXPANDED
+line 6
+assert_schema(other_json, :arg1, version: :arg2) # schema from path/schema.rb:1
+line 8
+      FILE
+    end
   end
 
 end


### PR DESCRIPTION
To make schema test files shorter, only include one expanded version per schema per file.