### PR TITLE
Serialize concurrent rewrites of schema test files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema-test (0.2.0)
+    schema-test (0.3.0)
       json
       json_schemer
 

--- a/lib/schema_test/minitest.rb
+++ b/lib/schema_test/minitest.rb
@@ -69,18 +69,20 @@ module SchemaTest
     end
 
     def expand_assert_api_calls
-     @@__api_schema_calls_for_expansion.each do |file, line_indexes_with_schemas|
-       original_contents = File.read(file)
-       rewriter_options = { disable_rubocop: SchemaTest.configuration.disable_rubocop }
-       rewriter = SchemaTest::Rewriter.new(original_contents, line_indexes_with_schemas, options: rewriter_options)
-       new_contents = rewriter.output
-       raise "Error rewriting file" if new_contents.blank?
-       File.open(file, 'w') { |f| f.puts new_contents }
-     end
+      @@__api_schema_calls_for_expansion.each do |file, line_indexes_with_schemas|
+        rewrite_file_safely(file) do |original_contents|
+          rewriter_options = { disable_rubocop: SchemaTest.configuration.disable_rubocop }
+          rewriter = SchemaTest::Rewriter.new(original_contents, line_indexes_with_schemas, options: rewriter_options)
+          new_contents = rewriter.output
+          raise "Error rewriting file" if new_contents.blank?
+          new_contents
+        end
+      end
     end
 
     @@__schema_fingerprints = {}
     @@__schema_fingerprint_hook_installed = false
+    @@__rewrite_mutex = Mutex.new
 
     def queue_write_schema_fingerprint(call_site, fingerprint)
       file, line = call_site.split(':')
@@ -97,9 +99,22 @@ module SchemaTest
 
     def write_schema_fingerprints
       @@__schema_fingerprints.each do |file, line_indexes_with_fingerprints|
-        original_contents = File.read(file)
-        rewriter = SchemaTest::FingerprintRewriter.new(original_contents, line_indexes_with_fingerprints)
-        File.open(file, 'w') { |f| f.print rewriter.output }
+        rewrite_file_safely(file) do |original_contents|
+          rewriter = SchemaTest::FingerprintRewriter.new(original_contents, line_indexes_with_fingerprints)
+          rewriter.output
+        end
+      end
+    end
+
+    def rewrite_file_safely(file)
+      @@__rewrite_mutex.synchronize do
+        File.open(file, File::RDWR) do |source|
+          source.flock(File::LOCK_EX)
+          rewritten_contents = yield source.read
+          source.rewind
+          source.write(rewritten_contents)
+          source.truncate(source.pos)
+        end
       end
     end
   end

--- a/lib/schema_test/version.rb
+++ b/lib/schema_test/version.rb
@@ -1,3 +1,3 @@
 module SchemaTest
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/schema_test/minitest_spec.rb
+++ b/spec/schema_test/minitest_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'schema_test/minitest'
+require 'tempfile'
+
+RSpec.describe SchemaTest::Minitest do
+  let(:harness) do
+    Class.new do
+      include SchemaTest::Minitest
+    end.new
+  end
+
+  it 'serializes concurrent rewrites of the same file' do
+    file = Tempfile.new
+    file.write("original\n")
+    file.close
+
+    first_started = Queue.new
+    release_first = Queue.new
+    second_started = Queue.new
+    second_contents = Queue.new
+
+    first = Thread.new do
+      harness.send(:rewrite_file_safely, file.path) do
+        first_started << true
+        release_first.pop
+        "first\n"
+      end
+    end
+    first_started.pop
+
+    second = Thread.new do
+      second_started << true
+      harness.send(:rewrite_file_safely, file.path) do |contents|
+        second_contents << contents
+        "second\n"
+      end
+    end
+    second_started.pop
+
+    expect(second_contents).to be_empty
+    release_first << true
+
+    [first, second].each(&:value)
+    expect(second_contents.pop).to eq("first\n")
+    expect(File.read(file.path)).to eq("second\n")
+  ensure
+    file&.unlink
+  end
+end


### PR DESCRIPTION
Use an exclusive file lock for each read-modify-write cycle. This prevents parallel test processes from overwriting changes from another process.

Add a concurrency test for the locked rewrite helper.